### PR TITLE
Bugfix for changed HP url

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,7 +3,7 @@
 - name: add public key (repository)
   apt_key:
     id: B1275EA3
-    url: http://downloads.linux.hp.com/SDR/downloads/MCP/GPG-KEY-mcp
+    url: http://downloads.linux.hpe.com/SDR/repo/mcp/GPG-KEY-mcp
     state: present
   tags:
     - configuration

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -2,8 +2,8 @@
 ---
 hp_proliant_support_pack_repositories:
   - type: deb
-    url: "http://downloads.linux.hp.com/SDR/repo/mcp/ubuntu {{ ansible_lsb.codename }}/current"
+    url: "http://downloads.linux.hpe.com/SDR/repo/mcp/ubuntu {{ ansible_lsb.codename }}/current"
     component: non-free
   - type: deb
-    url: "http://downloads.linux.hp.com/SDR/repo/mcp/ubuntu precise/current"
+    url: "http://downloads.linux.hpe.com/SDR/repo/mcp/ubuntu precise/current"
     component: non-free


### PR DESCRIPTION
```
curl: (6) Could not resolve host: PLEASE.USE.NEW.HOSTNAME___downloads.linux.HPE.com___
Download of http://downloads.linux.hp.com/SDR/repo/mcp/ubuntu/dists/trusty/current/Contents-amd64.gz failed
Command exited with code 6
curl: (22) The requested URL returned error: 404 Not Found
Download of http://downloads.linux.hp.com/SDR/repo/mcp/ubuntu/dists/precise/current/Contents-amd64.gz failed
Command exited with code 22
```
